### PR TITLE
Create action, attachment and test model factories

### DIFF
--- a/src/trytond_factories/__init__.py
+++ b/src/trytond_factories/__init__.py
@@ -2,6 +2,8 @@ __version__ = '6.2.0'
 
 from .tools import *  # NOQA: 401
 from .account import *  # NOQA: 401
+from .action import *  # NOQA: 401
+from .attachment import *  # NOQA: 401
 from .company import *  # NOQA: 401
 from .currency import *  # NOQA: 401
 from .invoice import *  # NOQA: 401
@@ -11,5 +13,6 @@ from .purchase import *  # NOQA: 401
 from .sale import *  # NOQA: 401
 from .sequence import *  # NOQA: 401
 from .stock import *  # NOQA: 401
+from .test import *  # NOQA: 401
 from .user import *  # NOQA: 401
 from .wizards import *  # NOQA: 401

--- a/src/trytond_factories/action.py
+++ b/src/trytond_factories/action.py
@@ -1,0 +1,75 @@
+
+__all__ = [
+    'Action',
+    'Keyword',
+    'Report',
+]
+
+import factory
+import factory_trytond
+
+
+class Action(factory_trytond.TrytonFactory):
+    class Meta:
+        model = 'ir.action'
+
+    name = factory.Faker('word')
+    type = factory.Faker('word', ext_word_list=['tree', 'form'])
+    records = 'selected'
+    usage = factory.Faker('word')
+    keywords = factory.RelatedFactoryList(
+        'trytond_factories.action.Keyword',
+        factory_related_name='action',
+        size=1,
+    )
+    icon = factory_trytond.LazySearch(
+        'ir.ui.icon',
+        lambda stub: [('module', '=', 'ir')],
+    )
+
+
+class Keyword(factory_trytond.TrytonFactory):
+    class Meta:
+        model = 'ir.action.keyword'
+
+    keyword = factory.Faker(
+        'word',
+        ext_word_list=[
+            'tree_open',
+            'form_print',
+            'form_action',
+            'form_relate',
+            'graph_open',
+        ]
+    )
+    action = factory.SubFactory('trytond_factories.action.Action')
+
+
+class Report(factory_trytond.TrytonFactory):
+    class Meta:
+        model = 'ir.action.report'
+
+    action = factory.SubFactory('trytond_factories.action.Action')
+    report_name = factory.Faker('word')
+    direct_print = True
+    single = True
+    translatable = True
+    template_extension = factory.Faker(
+        'word',
+        ext_word_list=[
+            'odt', 'odp', 'ods', 'odg', 'txt', 'xml', 'html', 'xhtml'
+        ]
+    )
+    extension = factory.Faker(
+        'word',
+        ext_word_list=[
+            '', 'bib', 'bmp', 'csv', 'dbf', 'dif', 'doc', 'doc6', 'doc95',
+            'docbook', 'docx', 'docx7', 'emf', 'eps', 'gif', 'html', 'jpg',
+            'met', 'ooxml', 'pbm', 'pct', 'pdb', 'pdf', 'pgm', 'png', 'ppm',
+            'ppt', 'psw', 'pwp', 'pxl', 'ras', 'rtf', 'latex', 'sda', 'sdc',
+            'sdc4', 'sdc3', 'sdd', 'sdd3', 'sdd4', 'sdw', 'sdw4', 'sdw3',
+            'slk', 'svg', 'svm', 'swf', 'sxc', 'sxi', 'sxd', 'sxd3', 'sxd5',
+            'sxw', 'text', 'tiff', 'txt', 'wmf', 'xhtml', 'xls', 'xls5',
+            'xls95', 'xlsx', 'xpm',
+        ],
+    )

--- a/src/trytond_factories/attachment.py
+++ b/src/trytond_factories/attachment.py
@@ -1,0 +1,34 @@
+
+__all__ = [
+    'DataAttachment',
+    'LinkAttachment',
+]
+
+import factory
+import factory_trytond
+
+
+class _Attachment(factory_trytond.TrytonFactory):
+    class Meta:
+        model = 'ir.attachment'
+
+    name = factory.Faker('word')
+    description = factory.Faker('sentence')
+    resource = factory.SubFactory('trytond_factories.test.TestModel')
+
+
+class DataAttachment(_Attachment):
+    class Meta:
+        model = 'ir.attachment'
+
+    type = 'data'
+    data = factory.Faker('binary', length=64)
+    file_id = factory.Faker('word')
+
+
+class LinkAttachment(_Attachment):
+    class Meta:
+        model = 'ir.attachment'
+
+    type = 'link'
+    link = factory.Faker('uri')

--- a/src/trytond_factories/test.py
+++ b/src/trytond_factories/test.py
@@ -1,0 +1,13 @@
+__all__ = [
+    'TestModel',
+]
+
+import factory
+import factory_trytond
+
+
+class TestModel(factory_trytond.TrytonFactory):
+    class Meta:
+        model = 'test.model'
+
+    name = factory.Faker('word')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,4 +5,5 @@ import pytest
 def trytond_modules():
     yield [
         'account_invoice',
+        'tests',
     ]

--- a/tests/test_trytond_factories.py
+++ b/tests/test_trytond_factories.py
@@ -5,3 +5,33 @@ def test_company(transaction):
     """Test Company factory"""
     company = trytond_factories.Company.create(party__name='A')
     assert company.party.name == 'A'
+
+
+def test_action(transaction):
+    """Test Action factory"""
+    action = trytond_factories.Action.create()
+    assert action
+
+
+def test_keyword(transaction):
+    """Test Keyword factory"""
+    keyword = trytond_factories.Keyword.create()
+    assert keyword
+
+
+def test_report(transaction):
+    """Test Report factory"""
+    report = trytond_factories.Report.create()
+    assert report
+
+
+def test_attachment_data(transaction):
+    """Test DataAttachment factory"""
+    data = trytond_factories.DataAttachment.create()
+    assert data
+
+
+def test_attachment_link(transaction):
+    """Test LinkAttachment factory"""
+    link = trytond_factories.LinkAttachment.create()
+    assert link


### PR DESCRIPTION
Action factories includes actions, keywords and reports models that can be safely created separately.

Attachments factories are DataAttachment (based on binary data) and LinkAttachment (based on web links).

Test Model factory is created as well because not only is necessary to link a resource to the recently
created attachment factory but also is very usefull with test when non specific model is necessary
(typically a M2O reference-like field).