### PR TITLE
Use PyPA's build tool to build our releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Install twine and wheel
+    - name: Install twine and build
       run: |
-        python3 -m pip install --upgrade pip twine wheel
+        python3 -m pip install --upgrade pip twine build
     - name: Prepare dist file
-      run: python3 setup.py bdist_wheel
+      run: python3 -m build
     - name: Publish dist on PyPI
       env:
         TWINE_USERNAME: __token__


### PR DESCRIPTION
Former commit https://github.com/calidae/trytond-factories/commit/92c670a9c02d5f68f7e073aa55e839fffde96053 removing the setup.py script should have
updated the release script to use a modern PEP-517 capable
building frontend.