### PR TITLE
Fix release workflow with modern boilerplate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,14 +10,21 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Install twine and build
-      run: |
-        python3 -m pip install --upgrade pip twine build
-    - name: Prepare dist file
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
+    - name: Install PyPA build
+      run: python3 -m pip install build
+
+    - name: Prepare distribuition
       run: python3 -m build
-    - name: Publish dist on PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-      run: python3 -m twine upload --non-interactive dist/*
+
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
- Use pypa/gh-action-pypi-publish action instead of Twine
- Upgrade checkout and setup-python actions