### PR TITLE
Remove deprecated on_change_with_account method in _Invoice factory

### DIFF
--- a/src/trytond_factories/invoice.py
+++ b/src/trytond_factories/invoice.py
@@ -44,7 +44,6 @@ class _Invoice(factory_trytond.TrytonFactory):
     def on_change(cls, obj):
         obj.on_change_type()
         obj.on_change_party()
-        obj.account = obj.on_change_with_account()
 
 
 class SupplierInvoice(_Invoice):


### PR DESCRIPTION
Due to commit https://github.com/tryton/tryton/commit/f2838915d4578018e4fe49b5d7b850b63eaa390f now account field from invoice instance is not set by on change with account method but also for on change type one.

This method also calls to on change party method, so this one can also be removed from the affected factory.